### PR TITLE
Disable deprecated declarations warning

### DIFF
--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -36,6 +36,9 @@ include_directories(src/VALfiles)
 
 find_package(FLEX REQUIRED)
 
+# Disable deprecated declarations warning (about std::auto_ptr)
+add_definitions(-Wno-deprecated-declarations)
+
 ## visualisation
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)


### PR DESCRIPTION
This change is required as a large number of warnings are being thrown, that cause the travis build for continuous integration to fail due to reaching the log length limit.

<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Update CMakeLists.txt to disable deprecated declarations warning as done in the master branch.

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
