### PR TITLE
[knowledge base] Case-sensitive VAL

### DIFF
--- a/rosplan_knowledge_base/src/VALfiles/lex.yy.cc
+++ b/rosplan_knowledge_base/src/VALfiles/lex.yy.cc
@@ -1783,8 +1783,6 @@ YY_RULE_SETUP
 {unsigned int i; 
           yylval.cp = new char[strlen(yytext)+1];
           strcpy(yylval.cp,yytext);
-	  for(i = 0;i<strlen(yylval.cp);i++)
-	      yylval.cp[i] = tolower(yylval.cp[i]);
 	  // If symbol is registered as a function symbol,
 	  // return token FUNCTION_SYMBOL else return NAME
 	  //cout << yytext << " " << line_no << "\n";

--- a/rosplan_knowledge_base/src/VALfiles/pddl+.lex
+++ b/rosplan_knowledge_base/src/VALfiles/pddl+.lex
@@ -140,8 +140,6 @@ at_time "at"{whitespace}{float}
 {string} {unsigned int i; 
           yylval.cp = new char[strlen(yytext)+1];
           strcpy(yylval.cp,yytext);
-	  for(i = 0;i<strlen(yylval.cp);i++)
-	      yylval.cp[i] = tolower(yylval.cp[i]);
 	  // If symbol is registered as a function symbol,
 	  // return token FUNCTION_SYMBOL else return NAME
 	  //cout << yytext << " " << line_no << "\n";


### PR DESCRIPTION
### Description

This PR simply prevents VAL from changing the case of domain attributes.

### Why is this necessary?

I noticed this was happening while working on https://github.com/b-it-bots/mas_knowledge_base/issues/15. In our ontology, object properties are written in mixed case (following the naming conventions at http://wiki.opensemanticframework.org/index.php/Ontology_Best_Practices). For the export of the ontology to work as expected, the case of the predicates in [our domestic planning domain](https://github.com/b-it-bots/mas_domestic_robotics/blob/kinetic/mdr_planning/mdr_rosplan_interface/config/default_domain.pddl) had to be adapted as well; however, after changing the case, I noticed that the names of the predicates are converted to lower case when the domain is parsed (e.g. `defaultStoringLocation` to `defaultstoringlocation`). This meant that predicate data could not be retrieved afterwards since property assertions are inserted into the knowledge base with the original case of the property name.

This problem is avoided by removing the lower case conversion that was done in VAL since predicates keep their original case now.

@DharminB Will your planning pipeline be affected by this change? As far as I can see, you use snake case in the [industrial domain](https://github.com/b-it-bots/mas_industrial_robotics/blob/kinetic/mir_planning/mir_knowledge/common/pddl/general_domain/domain.pddl), so I don't think it will be, but just to make sure.