### PR TITLE
Fixed skipping domain constant while inserting instances

### DIFF
--- a/rosplan_knowledge_base/src/PDDLKnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/PDDLKnowledgeBase.cpp
@@ -29,7 +29,7 @@ namespace KCL_rosplan {
                 // this is to prevent writing the domain constants
                 // to the problem file as well, which some planners
                 // complain about due to redefinition of constants
-                if (domain_constants.count(type->getName())) continue;
+                if (domain_constants.count(type->getName()) != 0 && domain_constants[type->getName()].size() > 0) continue;
 
                 res.types.push_back(type->getName());
                 if(type->type) res.super_types.push_back(type->type->getName());


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

- Instead of just checking if a key exists in `domain_constants` map, it will now check if the value of that key has size >1.

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Related to #4

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->

@alex-mitrevski 